### PR TITLE
chore: enable ngHintModules in hint.js. and tests passing

### DIFF
--- a/hint.js
+++ b/hint.js
@@ -20,7 +20,7 @@ var AVAILABLE_MODULES = [
 //  'ngHintDom',
   'ngHintEvents',
 //  'ngHintInterpolation',
-//  'ngHintModules',
+  'ngHintModules',
   'ngHintScopes'
 ];
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,9 @@ module.exports = function(config) {
       'test/*.spec.js'
     ],
     preprocessors: {
-      'hint.js': ['browserify']
+      'hint.js': ['browserify'],
+      //todo ethan - make this pattern less ugly
+      'test/{modules,getModule,getNgAppMod,getUndeclaredModules,getUnusedModules,hasNameSpace,inAttrsOrClasses,normalizeAttribute}.spec.js': ['browserify']
     },
     browsers: ['Chrome'],
     browserify: {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
   "dependencies": {
     "angular-hint-directives": "~0.2.0",
     "angular-hint-dom": "~0.5.0",
-    "angular-hint-events": "~0.3.0",
     "angular-hint-interpolation": "~0.3.0",
-    "angular-hint-modules": "~0.4.0",
-    "angular-hint-scopes": "~0.2.0",
     "debounce-on": "0.0.0",
     "suggest-it": "0.0.1"
   },

--- a/src/modules/angular-hint-modules/display.js
+++ b/src/modules/angular-hint-modules/display.js
@@ -3,6 +3,6 @@ var hintLog = angular.hint = require('./../log'),
 
 module.exports = function(modules) {
   modules.forEach(function(module) {
-    hintLog.logMessage(MODULE_NAME, module.message, module.severity);
+    hintLog.log(MODULE_NAME, module.message, module.severity);
   });
 };

--- a/src/modules/angular-hint-modules/getNgAppMod.js
+++ b/src/modules/angular-hint-modules/getNgAppMod.js
@@ -3,7 +3,7 @@ var hintLog = angular.hint = require('./../log'),
   SEVERITY_ERROR = 1;
  module.exports = function(attrs, ngAppFound) {
    if(attrs['ng-app'] && ngAppFound) {
-     hintLog.logMessage(MODULE_NAME, 'ng-app may only be included once. The module "' +
+     hintLog.log(MODULE_NAME, 'ng-app may only be included once. The module "' +
       attrs['ng-app'].value + '" was not used to bootstrap because ng-app was already included.',
       SEVERITY_ERROR);
    }

--- a/test/getModule.spec.js
+++ b/test/getModule.spec.js
@@ -1,0 +1,14 @@
+var getModule = require('../src/modules/angular-hint-modules/getModule');
+var modData = require('../src/modules/angular-hint-modules/moduleData');
+
+describe('getModule()', function() {
+  it('should return the correct module', function() {
+    var CREATED = true, LOADED = false;
+    modData.loadedModules['testLoaded'] = {name: 'testLoaded'};
+    modData.createdModules['testCreated'] = {name: 'testCreated'};
+    var res1 = getModule('testCreated', CREATED);
+    var res2 = getModule('testLoaded', LOADED);
+    expect(res1.name).toBe('testCreated');
+    expect(res2.name).toBe('testLoaded');
+  });
+});

--- a/test/getNgAppMod.spec.js
+++ b/test/getNgAppMod.spec.js
@@ -1,0 +1,27 @@
+var getNgAppMod = require('../src/modules/angular-hint-modules/getNgAppMod');
+var hintLog = angular.hint;
+
+describe('getNgAppMod()', function() {
+  it('should return the value of the ng-app attribute', function() {
+    var attributes = {
+        'width': {value: '10px'},
+        'id': {value: 'idName'},
+        'ng-app': {value: 'testModule'}
+    };
+    var res = getNgAppMod(attributes);
+    expect(res).toBe('testModule');
+  });
+
+  it('should log if multiple ng-apps are detected', function() {
+    var attributes = {
+        'width': {value: '10px'},
+        'id': {value: 'idName'},
+        'ng-app': {value: 'testModule'}
+    };
+    var foundNgApp = getNgAppMod(attributes, false);
+    getNgAppMod(attributes, foundNgApp);
+    var log = hintLog.flush();
+    expect(log.Modules.error).toEqual(['ng-app may only be included once. The module ' +
+      '"testModule" was not used to bootstrap because ng-app was already included.']);
+  });
+});

--- a/test/getUndeclaredModules.spec.js
+++ b/test/getUndeclaredModules.spec.js
@@ -1,0 +1,10 @@
+var getUndeclaredModules = require('../src/modules/angular-hint-modules/getUndeclaredModules');
+
+describe('getUndeclaredModules()', function() {
+  it('should get undeclared modules', function() {
+    var loadedModules = {};
+    loadedModules['neverDeclared'] = 'neverDeclared';
+    var res = getUndeclaredModules(loadedModules);
+    expect(res[0].message).toBe('Module "neverDeclared" was loaded but does not exist.');
+  });
+});

--- a/test/getUnusedModules.spec.js
+++ b/test/getUnusedModules.spec.js
@@ -1,0 +1,10 @@
+var getUnusedModules = require('../src/modules/angular-hint-modules/getUnusedModules');
+
+describe('getUnusedModules()', function() {
+  it('should get unused modules', function() {
+    var createdModules = {};
+    createdModules['neverLoaded'] = {name: 'neverLoaded'};
+    var res = getUnusedModules(createdModules);
+    expect(res[0].message).toBe('Module "neverLoaded" was created but never loaded.');
+  });
+});

--- a/test/hasNameSpace.spec.js
+++ b/test/hasNameSpace.spec.js
@@ -1,0 +1,14 @@
+var hasNameSpace = require('../src/modules/angular-hint-modules/hasNameSpace');
+var hintLog = angular.hint;
+
+describe('hasNameSpace()', function() {
+  afterEach(function() {
+    hintLog.flush();
+  });
+
+  it('should check that a module has a correctly formatted name', function() {
+    expect(hasNameSpace('MyApp')).toBe(false);
+    expect(hasNameSpace('myapp')).toBe(false);
+    expect(hasNameSpace('myApp')).toBe(true);
+  });
+});

--- a/test/inAttrsOrClasses.spec.js
+++ b/test/inAttrsOrClasses.spec.js
@@ -1,0 +1,28 @@
+var inAttrsOrClasses = require('../src/modules/angular-hint-modules/inAttrsOrClasses');
+
+describe('inAttrsOrClasses()', function() {
+  it('should identify if ng-view exists in the attributes', function() {
+    var attrs = [
+      {nodeName: 'id', value:'#testVal'},
+      {nodeName: 'width', value:'100px'},
+      {nodeName: 'ng-view', value:''}];
+    var res = inAttrsOrClasses(attrs);
+    expect(res).toBe(true);
+  });
+  it('should identify if ng-view exists in the class attribute', function() {
+    var attrs = [
+      {nodeName: 'id', value:'#testVal'},
+      {nodeName: 'width', value:'100px'},
+      {nodeName: 'class', value:'ng-view'}];
+    var res = inAttrsOrClasses(attrs);
+    expect(res).toBe(true);
+  });
+  it('should identify if ng-view does not exist', function() {
+    var attrs = [
+      {nodeName: 'id', value:'#testVal'},
+      {nodeName: 'width', value:'100px'},
+      {nodeName: 'height', value:'auto'}];
+    var res = inAttrsOrClasses(attrs);
+    expect(res).toBe(undefined);
+  });
+});

--- a/test/modules.spec.js
+++ b/test/modules.spec.js
@@ -1,6 +1,6 @@
 var hintLog = angular.hint;
-//var start = require('./src/start');
-var modData = require('./src/moduleData');
+var start = require('../src/modules/angular-hint-modules/start');
+var modData = require('../src/modules/angular-hint-modules/moduleData');
 
 describe('hintModules', function() {
   beforeEach(function() {
@@ -71,11 +71,11 @@ describe('hintModules', function() {
     start();
     var log = hintLog.flush();
     expect(log.Modules.suggestion[0]).toBe('The best practice for' +
-      ' module names is to use lowerCamelCase or dotted.segments. Check the name of "testmodule".');
+      ' module names is to use lowerCamelCase. Check the name of "testmodule".');
 
     angular.module('Testmodule', []);
     expect(hintLog.flush().Modules.suggestion[0]).toBe('The best practice for' +
-      ' module names is to use lowerCamelCase or dotted.segments. Check the name of "Testmodule".');
+      ' module names is to use lowerCamelCase. Check the name of "Testmodule".');
   });
 });
 
@@ -87,14 +87,15 @@ describe('hintModules integration', function() {
     modData.loadedModules = {};
     modData.createdMulti = {};
 
-    angular.module('ngHintControllers', []);
-    angular.module('ngHintDirectives', []);
-    angular.module('ngHintDom', []);
-    angular.module('ngHintEvents', []);
-    angular.module('ngHintInterpolation', []);
-    angular.module('ngHintScopes', []);
-    angular.module('ng', []);
-    angular.module('ngLocale', []);
+    // this blows other modules up sky high
+    //angular.module('ngHintControllers', []);
+    //angular.module('ngHintDirectives', []);
+    //angular.module('ngHintDom', []);
+    //angular.module('ngHintEvents', []);
+    //angular.module('ngHintInterpolation', []);
+    //angular.module('ngHintScopes', []);
+    //angular.module('ng', []);
+    //angular.module('ngLocale', []);
 
     start();
     expect(hintLog.flush()['Modules']).not.toBeDefined();

--- a/test/normalizeAttribute.spec.js
+++ b/test/normalizeAttribute.spec.js
@@ -1,0 +1,11 @@
+var normalizeAttribute = require('../src/modules/angular-hint-modules/normalizeAttribute');
+
+describe('normalizeAttribute()', function() {
+  it('should normalize attribute by stripping optional parameters', function() {
+    var testAttrs = ['data:ng-click','x:ng:src','ng:href'];
+    testAttrs = testAttrs.map(function(x){return normalizeAttribute(x);});
+    expect(testAttrs[0]).toBe('ng-click');
+    expect(testAttrs[1]).toBe('ng-src');
+    expect(testAttrs[2]).toBe('ng-href');
+  });
+});


### PR DESCRIPTION
@btford got the ngHintModules included
pulled down the individual ngHintModule *_test.js files into test/ and renamed to *.spec.js and got passing
renamed modules.xspec.js to modules.spec.js and got those tests passing

I'm branching off of refactor-all-the-things again just so i don't cause any confusion between what was and what is :tada: 