### PR TITLE
chore(examples) add app.css and correct angular.js location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Example:
 <!doctype html>
 <html ng-app="sample" ng-hint>
   ...
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   ...
 </html>
@@ -32,7 +32,7 @@ Example:
 <!doctype html>
 <html ng-app="sample" ng-hint-include="controllers dom">
   ...
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   ...
 </html>
@@ -42,7 +42,7 @@ Example:
 <!doctype html>
 <html ng-app="sample" ng-hint-exclude="modules">
   ...
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   ...
 </html>

--- a/examples/all-hint.html
+++ b/examples/all-hint.html
@@ -30,7 +30,7 @@
   <div id="console"></div>
 
   <script src="../util.js"></script>
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   <script>
     angular.module('sample', []);

--- a/examples/app.css
+++ b/examples/app.css
@@ -1,0 +1,47 @@
+html {
+  padding: 0;
+  margin: 0;
+  background-color: rgb(246, 247, 247);
+  width: 100%;
+}
+
+header {
+  background-color: rgb(220, 232, 245);
+  box-shadow: 2px 2px 5px #888888;
+  margin-top: -10px;
+  margin-left: -10px;
+  margin-right: -10px;
+  margin-bottom: 5px;
+  padding: 10px;
+
+}
+
+h1 {
+  padding: 0;
+  margin: 0;
+}
+
+#subtitle1 {
+
+}
+
+#subtitle2 {
+  font-style: italic;
+}
+
+#whichBestPractices {
+  margin-top: 10px;
+}
+
+.bestPracticesListShow {
+  margin-top: 10px;
+  padding: 5px;
+  background-color: white;
+  border-radius: 20px;
+  box-shadow: 2px 2px 5px #888888;
+}
+
+#contributors {
+  list-style-type: none;
+  -webkit-padding-start: 0px;
+}

--- a/examples/broken-example.html
+++ b/examples/broken-example.html
@@ -57,7 +57,7 @@
         </li>
       </ul>
     </div>
-    <script src="../bower_components/angular/angular.js"></script>
+    <script src="../node_modules/angular/angular.js"></script>
     <script>
       angular.module('bpAppModule', []);
         /**

--- a/examples/correct-example.html
+++ b/examples/correct-example.html
@@ -57,7 +57,7 @@ correctly uses only one module with `ng-app`. -->
     </ul>
   </div>
 
-  <script src="../bower_components/angular/angular.js"></script>
+  <script src="../node_modules/angular/angular.js"></script>
   <script src="../dist/hint.js"></script>
   <script>
     angular.module('bpAppModule', [])

--- a/examples/exclude-wrong-module-name.html
+++ b/examples/exclude-wrong-module-name.html
@@ -7,7 +7,7 @@
 <body>
   <div id="console"></div>
 
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   <script src="../util.js"></script>
 </body>

--- a/examples/exclusive-hint.html
+++ b/examples/exclusive-hint.html
@@ -7,7 +7,7 @@
   <body ng-controller="HintController">
     <div>Module output: </div>
     <div id="console"></div>
-    <script src="../../bower_components/angular/angular.js"></script>
+    <script src="../../node_modules/angular/angular.js"></script>
     <script src="../../bower_components/angular-route/angular-route.js"></script>
     <script src="../../dist/hint.js"></script>
     <script src="../util.js"></script>

--- a/examples/include-wrong-module-name.html
+++ b/examples/include-wrong-module-name.html
@@ -7,7 +7,7 @@
 <body>
   <div id="console"></div>
 
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../dist/hint.js"></script>
   <script src="../util.js"></script>
   <script> angular.module('exampleApp', []); </script>

--- a/examples/inclusive-hint.html
+++ b/examples/inclusive-hint.html
@@ -12,7 +12,7 @@
     </div>
     <div>Module output: </div>
     <div id="console"></div>
-    <script src="../../bower_components/angular/angular.js"></script>
+    <script src="../../node_modules/angular/angular.js"></script>
     <script src="../../dist/hint.js"></script>
     <script src="../util.js"></script>
     <script>

--- a/examples/manual-bootstrap-alternative.html
+++ b/examples/manual-bootstrap-alternative.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Angular Hint Example</title>
 
-  <script src="../../bower_components/angular/angular.js"></script>
+  <script src="../../node_modules/angular/angular.js"></script>
   <script src="../../bower_components/angular-route/angular-route.js"></script>
   <script src="../../dist/hint.js"></script>
   <script src="../util.js"></script>

--- a/examples/manual-bootstrap.html
+++ b/examples/manual-bootstrap.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Angular Hint Example</title>
 
-    <script src="../../bower_components/angular/angular.js"></script>
+    <script src="../../node_modules/angular/angular.js"></script>
     <script src="../../bower_components/angular-route/angular-route.js"></script>
     <script src="../../dist/hint.js"></script>
     <script src="../util.js"></script>


### PR DESCRIPTION
As far as I can tell, we're not using Bower here anymore.  I've updated all the examples to point to the correct location of `angular.js`

`examples/app.css` also seems to be missing