### PR TITLE
feat(events) Give angular.hint ability to emit events

### DIFF
--- a/hint.js
+++ b/hint.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Set up the event stuffs
+require('./src/modules/hintEmitter');
+
 // Create pipe for all hint messages from different modules
 require('./src/modules/log');
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "angular-hint-dom": "~0.5.0",
     "angular-hint-interpolation": "~0.3.0",
     "debounce-on": "0.0.0",
+    "eventemitter2": "^0.4.14",
     "suggest-it": "0.0.1"
   },
   "devDependencies": {

--- a/src/modules/hintEmitter.js
+++ b/src/modules/hintEmitter.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * We use EventEmitter2 here in order to have scoped events
+ * For instance:
+ *    hint.emit('scope:digest', {
+ */
+var EventEmitter2 = require('eventemitter2').EventEmitter2;
+
+angular.hint = new EventEmitter2({
+  wildcard: true,
+  delimiter: ':'
+});


### PR DESCRIPTION
angular.hint is now an EventEmitter and can emit capturable, namespaced events.  Previously `.emit` was just a noop.