### PR TITLE
bug(scopes): fix scope decorator to not break one time binding

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -78,6 +78,10 @@ function decorateRootScope($delegate, $parse) {
   var _watch = scopePrototype.$watch;
   var _digestEvents = [];
   scopePrototype.$watch = function (watchExpression, reactionFunction) {
+    if (typeof watchExpression === 'string' &&
+        isOneTimeBindExp(watchExpression)) {
+      return _watch.apply(this, arguments);
+    }
     var watchStr = humanReadableWatchExpression(watchExpression);
     var scopeId = this.$id;
     if (typeof watchExpression === 'function') {
@@ -306,4 +310,10 @@ function humanReadableWatchExpression (fn) {
     fn = fn.name;
   }
   return fn.toString();
+}
+
+function isOneTimeBindExp(exp) {
+  // this is the same code angular 1.3.15 has to check
+  // for a one time bind expression
+  return exp.charAt(0) === ':' && exp.charAt(1) === ':';
 }


### PR DESCRIPTION
since we patch `$watch` to be able to run performance timers, we always pass a function to the original `$watch` which in turn passes it to `$parse` where only string expressions is allowed to be a one time binding which means our patch breaks one time binding expressions. Skip one perf timers for one time binding since it isn't too helpful anyways since its only a one time bind.

We will ask the angular team for some introspection hooks and a strict mode so that we don't have to keep on patching angular core methods to be able to run perf timers.

fixes: https://github.com/angular/angularjs-batarang/issues/209