### PR TITLE
Scope id not sent with scope:destroy message

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -147,7 +147,7 @@ function decorateRootScope($delegate, $parse) {
 
   var _destroy = scopePrototype.$destroy;
   scopePrototype.$destroy = function () {
-    var id = this.id;
+    var id = this.$id;
 
     hint.emit('scope:destroy', { id: id });
 

--- a/test/scopes.spec.js
+++ b/test/scopes.spec.js
@@ -128,7 +128,7 @@ describe('ngHintScopes', function() {
       var args = getArgsOfNthCall(0);
 
       expect(args[0]).toBe('scope:destroy');
-      expect(args[1].id).toBe(scope.id);
+      expect(args[1].id).toBe(scope.$id);
     });
   });
 


### PR DESCRIPTION
There is an issue with Batarang in which scopes are never deleted from the scope tree. This is caused (in part) because the id of the scope isn't passed through from ngHint. 
I have not got the SauceLabs tests setup locally. 
I presume these are executed automatically anyway by the CI server.
A PR for Batarang with the rest of the changes required to fix this bug is incoming.
