### PR TITLE
fix(modules): Add case for modules without namespace

### DIFF
--- a/src/modules/angular-hint-modules/hasNameSpace.js
+++ b/src/modules/angular-hint-modules/hasNameSpace.js
@@ -6,10 +6,15 @@ module.exports = function(str) {
     return true;
   }
 
-  if(str.toLowerCase() === str || str.charAt(0).toUpperCase() === str.charAt(0)) {
+  if(str.charAt(0).toUpperCase() === str.charAt(0)) {
     angular.hint.emit(MODULE_NAME, 'The best practice for' +
-      ' module names is to use lowerCamelCase. Check the name of "' + str + '".',
+      ' module names is to use dot.case or lowerCamelCase. Check the name of "' + str + '".',
       SEVERITY_SUGGESTION);
+    return false;
+  }
+  if(str.toLowerCase() === str && str.indexOf('.') === -1) {
+    angular.hint.emit(MODULE_NAME, 'Module names should be namespaced' +
+      ' with a dot (app.dashboard) or lowerCamelCase (appDashboard). Check the name of "' + str + '".', SEVERITY_SUGGESTION);
     return false;
   }
   return true;

--- a/test/hasNameSpace.spec.js
+++ b/test/hasNameSpace.spec.js
@@ -13,6 +13,20 @@ describe('hasNameSpace()', function() {
     expect(hasNameSpace('MyApp')).toBe(false);
     expect(hasNameSpace('myapp')).toBe(false);
     expect(hasNameSpace('myApp')).toBe(true);
+    expect(hasNameSpace('my.app')).toBe(true);
+  });
+
+  it('should warn about a non-namespaced module', function() {
+    angular.module('app', []);
+    start();
+    var formattingWarning = angular.hint.emit.calls.allArgs()
+      .filter(function(warningArray) {
+        return warningArray[0] === 'Modules' &&
+          warningArray[1] === 'Module names should be namespaced' +
+      ' with a dot (app.dashboard) or lowerCamelCase (appDashboard). Check the name of "app".' &&
+          warningArray[2] === SEVERITY_SUGGESTION;
+      });
+    expect(formattingWarning.length).toBe(1);
   });
 
   it('should only warn once about incorrect formatting for a module', function() {
@@ -24,7 +38,7 @@ describe('hasNameSpace()', function() {
       .filter(function(warningArray) {
         return warningArray[0] === 'Modules' &&
           warningArray[1] === 'The best practice for module names is' +
-          ' to use lowerCamelCase. Check the name of "MyApp".' &&
+          ' to use dot.case or lowerCamelCase. Check the name of "MyApp".' &&
           warningArray[2] === SEVERITY_SUGGESTION;
       });
     expect(formattingWarning.length).toBe(1);

--- a/test/modules.spec.js
+++ b/test/modules.spec.js
@@ -71,12 +71,12 @@ describe('hintModules', function() {
   it('should warn if modules are not named with lowerCamelCase or dotted.segments', function() {
     angular.module('testmodule', []);
     start();
-    expect(angular.hint.emit).toHaveBeenCalledWith('Modules', 'The best practice for' +
-      ' module names is to use lowerCamelCase. Check the name of "testmodule".', 3);
+    expect(angular.hint.emit).toHaveBeenCalledWith('Modules', 'Module names should be namespaced' +
+      ' with a dot (app.dashboard) or lowerCamelCase (appDashboard). Check the name of "testmodule".', 3);
 
     angular.module('Testmodule', []);
     expect(angular.hint.emit).toHaveBeenCalledWith('Modules', 'The best practice for' +
-      ' module names is to use lowerCamelCase. Check the name of "Testmodule".', 3);
+      ' module names is to use dot.case or lowerCamelCase. Check the name of "Testmodule".', 3);
   });
 });
 


### PR DESCRIPTION
This commit allows the use of dot namespacing (app.dashboard) as well as adds another case checking for modules without namespaces

fixes #61