### PR TITLE
fix(scopes) handle watches on null expression

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -304,6 +304,9 @@ function byScopeId (scope) {
 }
 
 function humanReadableWatchExpression (fn) {
+  if (fn == null) {
+    return null;
+  }
   if (fn.exp) {
     fn = fn.exp;
   } else if (fn.name) {

--- a/test/scopes.spec.js
+++ b/test/scopes.spec.js
@@ -20,34 +20,35 @@ describe('ngHintScopes', function() {
     });
 
     it('should run perf timers for string expressions', function() {
-      var calls = hint.emit.calls;
       scope.$watch('a.b', function() {});
-      expect(calls.count()).toBe(0);
+      expect(hint.emit.calls.count()).toBe(0);
 
       scope.$apply();
-      var evt = calls.mostRecent().args[1].events[0];
-      expect(calls.count()).toBe(1);
-      expect(evt.time).toEqual(jasmine.any(Number));
-      evt.time = null
-      expect(evt).toEqual({
+      var expectedEvent = {
         eventType: 'scope:watch',
         id: scope.$id,
         watch: 'a.b',
         time: null
-      });
+      };
+      checkMostRecentCall(1, expectedEvent);
+      scope.$apply();
+      checkMostRecentCall(2, expectedEvent);
+    });
+
+    it('should handle null watchExpression', function() {
+      scope.$watch(null, function() {});
+      expect(hint.emit.calls.count()).toBe(0);
 
       scope.$apply();
-      expect(calls.count()).toBe(2);
-      var evt = calls.mostRecent().args[1].events[0];
-      expect(evt.time).toEqual(jasmine.any(Number));
-      evt.time = null
-      expect(evt).toEqual({
+      var expectedEvent = {
         eventType: 'scope:watch',
         id: scope.$id,
-        watch: 'a.b',
+        watch: null,
         time: null
-      });
-
+      };
+      checkMostRecentCall(1, expectedEvent);
+      scope.$apply();
+      checkMostRecentCall(2, expectedEvent);
     });
 
     if (angular.version.minor >= 3) {
@@ -69,6 +70,17 @@ describe('ngHintScopes', function() {
         expect(calls.count()).toBe(2);
         expect(evt).toBeUndefined();
       });
+    }
+
+    // the event's time property is set to null before comparison with expectedEvent, so callers
+    // should set the time property on expectedEvent to null as well
+    function checkMostRecentCall(expectedCount, expectedEvent){
+      var calls = hint.emit.calls;
+      var evt = calls.mostRecent().args[1].events[0];
+      expect(calls.count()).toBe(expectedCount);
+      expect(evt.time).toEqual(jasmine.any(Number));
+      evt.time = null;
+      expect(evt).toEqual(expectedEvent);
     }
   });
 


### PR DESCRIPTION
Passing null as first parameter to the $scope.$watch function caused a null reference exception within hint.js that interferes with the loading of the users app. Adding a null check to resolve this issue.

Fixes issue #94