### PR TITLE
fix(scopes) maintain id data type

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -40,7 +40,7 @@ function decorateRootScope($delegate, $parse) {
         value: value
       };
       hint.emit('model:change', {
-        id: scopeId,
+        id: convertIdToOriginalType(scopeId),
         path: partialPath,
         value: value
       });
@@ -247,7 +247,7 @@ function decorateRootScope($delegate, $parse) {
         var value = summarize(model.get());
         if (value !== model.value) {
           hint.emit('model:change', {
-            id: (angular.version.minor < 3) ? scopeId : parseInt(scopeId),
+            id: convertIdToOriginalType(scopeId),
             path: path,
             oldValue: model.value,
             value: value
@@ -336,4 +336,8 @@ function isOneTimeBindExp(exp) {
   // this is the same code angular 1.3.15 has to check
   // for a one time bind expression
   return exp.charAt(0) === ':' && exp.charAt(1) === ':';
+}
+
+function convertIdToOriginalType(scopeId) {
+  return (angular.version.minor < 3) ? scopeId : parseInt(scopeId, 10);
 }

--- a/test/scopes.spec.js
+++ b/test/scopes.spec.js
@@ -363,6 +363,15 @@ describe('ngHintScopes', function() {
       });
     });
 
+    it('should accept an id as a string and return the id in the data type the current angular version uses', function() {
+      hint.watch('' + scope.$id, '');
+
+      expect(hint.emit).toHaveBeenCalled();
+
+      var args = getArgsOfNthCall(0);
+      expect(args[0]).toBe('model:change');
+      expect(args[1].id).toBe(scope.$id);
+    });
   });
 
 


### PR DESCRIPTION
In batarang if you do not have the scopes tab open when the app loads or if you navigate to another tab after the app has loaded the jsonTree stops working correctly. This was down to it ignoring model:change events. This was caused by the fact angular 1.3+ uses int ids while batarang was storing them as keys in objects. It would pass hint the id as a string, hint would find the scope and emit an event, but would also echo back the id as a string. Problem is the jsonTree maintains a type correct version of the Id, and strict comparisons then failed, hence no UI update occurred. Updating so hint always returns the id in the type dictated by the current angular version, regardless of the type of the id passed to it. 