### PR TITLE
fix(modules): Don't re-register modules we've seen before

### DIFF
--- a/dist/hint.js
+++ b/dist/hint.js
@@ -1048,8 +1048,12 @@ module.exports = function(doms) {
 },{"./getNgAppMod":11,"./inAttrsOrClasses":15,"./moduleData":16,"./storeDependencies":20}],22:[function(require,module,exports){
 var storeDependencies = require('./storeDependencies');
 
+var seen = [];
+
 var storeUsedModules = module.exports = function(module, modules){
-  if(module) {
+  var name = module.name || module;
+  if(module && seen.indexOf(name) === -1) {
+    seen.push(name);
     storeDependencies(module);
     module.requires.forEach(function(modName) {
       var mod = modules[modName];

--- a/src/modules/angular-hint-modules/storeUsedModules.js
+++ b/src/modules/angular-hint-modules/storeUsedModules.js
@@ -1,7 +1,11 @@
 var storeDependencies = require('./storeDependencies');
 
+var seen = [];
+
 var storeUsedModules = module.exports = function(module, modules){
-  if(module) {
+  var name = module.name || module;
+  if(module && seen.indexOf(name) === -1) {
+    seen.push(name);
     storeDependencies(module);
     module.requires.forEach(function(modName) {
       var mod = modules[modName];


### PR DESCRIPTION
When recursively tracking modules, we will hit a stack overflow if two modules depend on each other.
Track modules we've seen and don't re-register them if we've seen them before.

Fixes https://github.com/angular/batarang/issues/200