### PR TITLE
fix($watch): don't break

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -142,7 +142,7 @@ function decorateRootScope($delegate, $parse) {
         var end = perf.now();
         _digestEvents.push({
           eventType: 'scope:reaction',
-          id: this.$id,
+          id: scopeId,
           watch: watchStr,
           time: end - start
         });


### PR DESCRIPTION
Due to a change introduced in AngularJS `v1.5.0` (https://github.com/angular/angular.js/commit/1c6edd416b4baad0c8b01148f429eb78e0ad7eaa), the `watchAction` callback is called without a context (i.e. `this === undefined`). This caused an error while trying to access `this.$id`.

Fixes angular/batarang#285