### PR TITLE
fix 109: trim spaces to fix one-time expression detection

### DIFF
--- a/src/modules/scopes.js
+++ b/src/modules/scopes.js
@@ -358,6 +358,7 @@ function humanReadableWatchExpression (fn) {
 function isOneTimeBindExp(exp) {
   // this is the same code angular 1.3.15 has to check
   // for a one time bind expression
+  exp = exp.trim();
   return exp.charAt(0) === ':' && exp.charAt(1) === ':';
 }
 


### PR DESCRIPTION
this fixes https://github.com/angular/angular-hint/issues/109 allowing for both `{{ ::` and  `{{::` which are valid syntax for one-time bindings.

The same is done in Angular 1.5.8 when detecting one-time binding in string expressions.
