### PR TITLE
Update Angular + suggest-it dependencies

### DIFF
--- a/dist/hint.js
+++ b/dist/hint.js
@@ -927,22 +927,21 @@ function defaultHash () {
 module.exports = distance;
 
 function distance(a, b) {
-  var table = [];
+  var table = [], diag = 0, left, top;
   if (a.length === 0 || b.length === 0) return Math.max(a.length, b.length);
   for (var ii = 0, ilen = a.length + 1; ii !== ilen; ++ii) {
-    table[ii] = [];
     for (var jj = 0, jlen = b.length + 1; jj !== jlen; ++jj) {
-      if (ii === 0 || jj === 0) table[ii][jj] = Math.max(ii, jj);
+      if (ii === 0 || jj === 0) table[jj] = Math.max(ii, jj);
       else {
-        var diagPenalty = Number(a[ii-1] !== b[jj-1]);
-        var diag = table[ii - 1][jj - 1] + diagPenalty;
-        var top = table[ii - 1][jj] + 1;
-        var left = table[ii][jj - 1] + 1;
-        table[ii][jj] = Math.min(left, top, diag);
+        diag += Number(a[ii-1] !== b[jj-1]);
+        left = table[jj - 1] + 1;
+        top = table[jj] + 1;
+        table[jj] = Math.min(left, top, diag);
+        diag = top - 1;
       }
     }
   }
-  return table[a.length][b.length];
+  return table[b.length];
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-hint",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "run-time hinting for AngularJS applications",
   "main": "hint.js",
   "scripts": {
@@ -30,11 +30,11 @@
   "dependencies": {
     "debounce-on": "^0.0.0",
     "eventemitter2": "^4.0.0",
-    "suggest-it": "^0.0.1"
+    "suggest-it": "^0.0.2"
   },
   "devDependencies": {
-    "angular": "^1.6.3",
-    "angular-mocks": "^1.6.3",
+    "angular": "^1.6.6",
+    "angular-mocks": "^1.6.6",
     "browserify": "^14.1.0",
     "gulp": "^3.9.1",
     "http-server": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,13 +62,13 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-angular-mocks@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.6.3.tgz#12fafc0f1e0903f16864004ba375bf3fb9101ef1"
+angular-mocks@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.6.6.tgz#c93018e7838c6dc5ceaf1a6bcf9be13c830ea515"
 
-angular@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.3.tgz#5d34b799234e8fa17c6a3a14e0258733935f43e7"
+angular@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.6.tgz#fd5a3cfb437ce382d854ee01120797978527cb64"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -3151,9 +3151,9 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-suggest-it@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/suggest-it/-/suggest-it-0.0.1.tgz#bcbd79c299af7b8aa188fcc8abb6d4406136a74c"
+suggest-it@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/suggest-it/-/suggest-it-0.0.2.tgz#8621b38f3a066e96f2171f600c198c8f94f53167"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This solves the following problems:
 * (temporary fix) not being able to use this in any Firefox add-on due to https://github.com/mozilla/addons-linter/blob/52815f8d4c3b68e787263b70b646dcf336c7ff17/docs/third-party-libraries.md
 * fix: engine "node" is incompatible with this module https://github.com/CrypticSwarm/suggest-it/issues/3 & https://github.com/CrypticSwarm/suggest-it/pull/4